### PR TITLE
Improved masks of Emissary banks

### DIFF
--- a/Mods/messengersAndEmissaries/content/config/creatureBanks/legendsLibrary.json
+++ b/Mods/messengersAndEmissaries/content/config/creatureBanks/legendsLibrary.json
@@ -12,7 +12,7 @@
 					"base" : {
 						"animation" : "creatureBanks/ZCrBGod4.def",
 						"visitableFrom" : [ "---", "-+-", "+++" ],
-						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBABB", "VBBVBV", "VVBVVV" ]
+						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBBBB", "VBBBBV", "VBBABV" ]
 					}
 				},
 				"rmg" : {

--- a/Mods/messengersAndEmissaries/content/config/creatureBanks/magiciansMonastery.json
+++ b/Mods/messengersAndEmissaries/content/config/creatureBanks/magiciansMonastery.json
@@ -12,7 +12,7 @@
 					"base" : {
 						"animation" : "creatureBanks/ZCrBGod3.def",
 						"visitableFrom" : [ "---", "-+-", "+++" ],
-						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBABB", "VBBVBV", "VVBVVV" ]
+						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBBBB", "VBBBBV", "VBBABV" ]
 					}
 				},
 				"rmg" : {

--- a/Mods/messengersAndEmissaries/content/config/creatureBanks/martialSpiritPalace.json
+++ b/Mods/messengersAndEmissaries/content/config/creatureBanks/martialSpiritPalace.json
@@ -12,7 +12,7 @@
 					"base" : {
 						"animation" : "creatureBanks/ZCrBGod1.def",
 						"visitableFrom" : [ "---", "-+-", "+++" ],
-						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBABB", "VBBVBV", "VVBVVV" ]
+						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBBBB", "VBBBBV", "VBBABV" ]
 					}
 				},
 				"rmg" : {

--- a/Mods/messengersAndEmissaries/content/config/creatureBanks/pacificationCitadel.json
+++ b/Mods/messengersAndEmissaries/content/config/creatureBanks/pacificationCitadel.json
@@ -12,7 +12,7 @@
 					"base" : {
 						"animation" : "creatureBanks/ZCrBGod2.def",
 						"visitableFrom" : [ "---", "-+-", "+++" ],
-						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBABB", "VBBVBV", "VVBVVV" ]
+						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBBBB", "VBBBBV", "VBBABV" ]
 					}
 				},
 				"rmg" : {

--- a/Mods/wogGraphicFix/Mods/wf_mapObjects/content/config/wgfCreatureBanks.json
+++ b/Mods/wogGraphicFix/Mods/wf_mapObjects/content/config/wgfCreatureBanks.json
@@ -7,8 +7,8 @@
 				"templates" : {
 					"small" : {
 						"animation" : "creatureBanks/WGgod1.def",
-						"visitableFrom" : [ "---", "-+-", "+++" ],
-						"mask" : [ "VVVVVV", "VVVVVV", "VBBBBV", "VBBABV", "VBBVBV", "VVVVVV"]
+						"visitableFrom" : [ "---", "-+-", "-+-" ],
+						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBABB", "VBB0BV", "000000" ]
 					}
 				}
 			},
@@ -18,8 +18,8 @@
 				"templates" : {
 					"small" : {
 						"animation" : "creatureBanks/WGgod2.def",
-						"visitableFrom" : [ "---", "-+-", "+++" ],
-						"mask" : [ "VVVVVV", "VVVVVV", "VBBBBV", "VBBABV", "VBBVBV", "VVVVVV"]
+						"visitableFrom" : [ "---", "-+-", "-+-" ],
+						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBABB", "VBB0BV", "000000" ]
 					}
 				}
 			},
@@ -29,8 +29,8 @@
 				"templates" : {
 					"small" : {
 						"animation" : "creatureBanks/WGgod3.def",
-						"visitableFrom" : [ "---", "-+-", "+++" ], 
-						"mask" : [ "VVVVVV", "VVVVVV", "VBBBBV", "VBBABV", "VBBVBV", "VVVVVV"]
+						"visitableFrom" : [ "---", "-+-", "-+-" ], 
+						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBABB", "VBB0BV", "000000" ]
 					}
 				}
 			},
@@ -40,8 +40,8 @@
 				"templates" : {
 					"small" : {
 						"animation" : "creatureBanks/WGgod4.def",
-						"visitableFrom" : [ "---", "-+-", "+++" ], 
-						"mask" : [ "VVVVVV", "VVVVVV", "VBBBBV", "VBBABV", "VBBVBV", "VVVVVV"]
+						"visitableFrom" : [ "---", "-+-", "-+-" ], 
+						"mask" : [ "VVVVVV", "VVBBVV", "VBBBBB", "BBBABB", "VBB0BV", "000000" ]
 					}
 				}
 			}

--- a/mod.json
+++ b/mod.json
@@ -4,7 +4,7 @@
 	"modType" : "Expansion",
 	"author" : "WoG Team & epigones",
 	"contact" : "http://forum.vcmi.eu/index.php",
-	"version" : "9.1.7",
+	"version" : "9.1.8",
 	"downloadSize" : 68.9,
 	"compatibility" :
 	{
@@ -12,6 +12,7 @@
 	},
 	"changelog" :
 	{
+		"9.1.8"   : [ "Changed mask of Emissary banks so they can spawn on random maps." ],
 		"9.1.7"   : [ "Fixed Mirror of Home-Way mask. Also, gold will not use Mithril skin anymore." ],
 		"9.1.6"   : [ "WoG Graphics Fix mod updated based on Grossmaster's 2.15 version" ],
 		"9.1.5"   : [ "Alms House will now use new selectAll feature for rewards"],


### PR DESCRIPTION
Fixed masks so RMG can place them correctly, with all objects visible.

GraphicFix version may look weird, as it uses template of base object. It it a bug in RMG.