### PR TITLE
Fixed loading of maps with mithril piles

### DIFF
--- a/Mods/mapDecorations/content/config/mapDecorations/wogStatic/mithril.json
+++ b/Mods/mapDecorations/content/config/mapDecorations/wogStatic/mithril.json
@@ -1,9 +1,11 @@
 {
-	"mithril" : {
-		"name" : "Mithril (does nothing yet)",
-		"handler" : "generic",
+	"core:resource" : { 
 		"types" : {
+			// WARNING: critical for maps support, if changed, ensure that maps with pre-placed mithril piles can still be loaded
 			"mithril" : {
+				"resource" : "gold",
+				"amounts" : [ 10, 15, 20 ],
+				"amountMultiplier" : 100,
 				"templates" : {
 					"zmithr" : {
 						"animation" : "objects/zmithr.def",

--- a/Mods/mapSupport/mod.json
+++ b/Mods/mapSupport/mod.json
@@ -230,7 +230,9 @@
 						"zchst4" : [101, 4],
 						"zchst5" : [101, 5]
 					},
-					"mithril" : [79, 7],
+					"resource" : {
+						"mithril" : [79, 7],
+					}
 					"opalOfMagic" : [101, 7],
 					"rubyOfOffence" : [101, 8],
 					"sapphireOfDefense" : [101, 9],

--- a/mod.json
+++ b/mod.json
@@ -4,13 +4,16 @@
     "modType" : "Expansion",
     "author" : "WoG Team & epigones",
     "contact" : "http://forum.vcmi.eu/index.php",
-    "version" : "9.1.45",
+    "version" : "9.1.46",
     "downloadSize" : 68.9,
     "compatibility" : {
         "min" : "1.6.0"
     },
     "changelog" : {
-	"9.1.45" : [
+        "9.1.46" : [
+            "Fixed loading of wake of gods maps that contain mithril piles"
+        ],
+        "9.1.45" : [
             "WoG theme fixed"
         ],
         "9.1.44" : [


### PR DESCRIPTION
Mithril piles will now load as piles of 1000 / 1500 / 2000 gold.

Feel free to suggest different amounts / resource type, but mithril piles MUST be loaded as a resource pile. In theory can be loaded as actual mithril, but no idea whether mithril actually functions in current vcmi build.

Requires vcmi 1.6.4